### PR TITLE
use SDK v3.6+ and change to support non-english characters

### DIFF
--- a/src/js/pebble-js-app.js
+++ b/src/js/pebble-js-app.js
@@ -100,16 +100,16 @@ Skunk.onShowConfiguration = function() {
   if (!window.localStorage.config || window.localStorage.config == "") {
     var url = Skunk.domain + '/settings';
   } else {
-    var url = Skunk.domain + '/settings#' + base64_encode(window.localStorage.config);
+    var url = Skunk.domain + '/settings#' + encodeURIComponent(window.localStorage.config);
   }
   Pebble.openURL(url);
 };
 
 Skunk.onWebViewClosed = function(event) {
-  var response = event.response;
-  if (!response || base64_decode(response).indexOf('{') === -1) return;
+  var response = decodeURIComponent(event.response);
+  if (!response || response.indexOf('{') === -1) return;
 
-  window.localStorage.config = base64_decode(response);
+  window.localStorage.config = response;
 
   Pebble.sendAppMessage({pushing_data: true});
 };

--- a/src/pager_layer.c
+++ b/src/pager_layer.c
@@ -4,7 +4,7 @@ struct PagerLayer {
     Layer *layer;
     uint8_t index;
     uint8_t count;
-    GTextLayoutCacheRef cache;
+    /*interval use only: GTextLayoutCacheRef cache; */
 };
 
 static const GSize outer_size = { 7, 7 }; // TODO: Fix magic numbers
@@ -66,7 +66,7 @@ static void background_update_proc(Layer *layer, GContext* ctx) {
             bounds,
             GTextOverflowModeFill,
             GTextAlignmentCenter,
-            pager_layer->cache
+            NULL //pager_layer->cache (always NULL for third-party apps)
         );
     } else {
         GRect rect = GRect(0, 0, outer_size.w * count + padding * (count - 1), outer_size.h);


### PR DESCRIPTION
Some changes for compiling SDK v3.6 and displaying non-english characters.
The '**/script.js**' should be modified to accept `encodeURIComponent()`, `decodeURIComponent()` functions around 76, 219 lines:

line#76
```
$(document).ready(function() {
  var data = jQuery.parseJSON(decodeURIComponent(window.location.hash.substring(1)));

  if (data !== "") {
    renderData(data);
  }
});
```

line#219
```
function generatePebbleURL() {
  data = collectData(true);

  if (!data) {
    return;
  }

  data_str = encodeURIComponent(JSON.stringify(data));

  location.href = 'pebblejs://close#' + data_str;
}
```